### PR TITLE
Expo plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.79.0](https://github.com/rnw-community/rnw-community/compare/v0.78.1...v0.79.0) (2024-11-18)
+
+### Features
+
+-   **react-native-payments:** request only contact fields asked for by the user ([#231](https://github.com/rnw-community/rnw-community/issues/231)) ([67021f7](https://github.com/rnw-community/rnw-community/commit/67021f759b5a3ef863967fad43aa28d6f9e2a20b))
+
 ## [0.78.1](https://github.com/rnw-community/rnw-community/compare/v0.78.0...v0.78.1) (2024-11-18)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.78.1](https://github.com/rnw-community/rnw-community/compare/v0.78.0...v0.78.1) (2024-11-18)
+
+### Bug Fixes
+
+-   Corrected a typo in the supportedNetworks example code (MasterCard -> Mastercard) ([#248](https://github.com/rnw-community/rnw-community/issues/248)) ([7dd19d3](https://github.com/rnw-community/rnw-community/commit/7dd19d37b7a4b219299b73215260882dfe4ab610))
+
 # [0.78.0](https://github.com/rnw-community/rnw-community/compare/v0.77.0...v0.78.0) (2024-11-13)
 
 ### Features

--- a/lerna.json
+++ b/lerna.json
@@ -7,5 +7,5 @@
         }
     },
     "npmClient": "yarn",
-    "version": "0.78.1"
+    "version": "0.79.0"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -7,5 +7,5 @@
         }
     },
     "npmClient": "yarn",
-    "version": "0.78.0"
+    "version": "0.78.1"
 }

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.79.0](https://github.com/rnw-community/rnw-community/compare/v0.78.1...v0.79.0) (2024-11-18)
+
+**Note:** Version bump only for package @rnw-community/eslint-plugin
+
 # [0.78.0](https://github.com/rnw-community/rnw-community/compare/v0.77.0...v0.78.0) (2024-11-13)
 
 **Note:** Version bump only for package @rnw-community/eslint-plugin

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnw-community/eslint-plugin",
-    "version": "0.78.0",
+    "version": "0.79.0",
     "description": "RNW-Community ESLint plugin",
     "keywords": [
         "eslint",

--- a/packages/fast-style/CHANGELOG.md
+++ b/packages/fast-style/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.79.0](https://github.com/rnw-community/rnw-community/compare/v0.78.1...v0.79.0) (2024-11-18)
+
+**Note:** Version bump only for package @rnw-community/fast-style
+
 # [0.78.0](https://github.com/rnw-community/rnw-community/compare/v0.77.0...v0.78.0) (2024-11-13)
 
 **Note:** Version bump only for package @rnw-community/fast-style

--- a/packages/fast-style/package.json
+++ b/packages/fast-style/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnw-community/fast-style",
-    "version": "0.78.0",
+    "version": "0.79.0",
     "description": "Fast react native flex and font styling",
     "keywords": [
         "object field tree",

--- a/packages/nestjs-enterprise/CHANGELOG.md
+++ b/packages/nestjs-enterprise/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.79.0](https://github.com/rnw-community/rnw-community/compare/v0.78.1...v0.79.0) (2024-11-18)
+
+**Note:** Version bump only for package @rnw-community/nestjs-enterprise
+
 # [0.78.0](https://github.com/rnw-community/rnw-community/compare/v0.77.0...v0.78.0) (2024-11-13)
 
 ### Features

--- a/packages/nestjs-enterprise/package.json
+++ b/packages/nestjs-enterprise/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnw-community/nestjs-enterprise",
-    "version": "0.78.0",
+    "version": "0.79.0",
     "description": "NestJS Enterprise is a collection of enterprise-grade modules for NestJS.",
     "keywords": [
         "nestjs",

--- a/packages/nestjs-rxjs-lock/CHANGELOG.md
+++ b/packages/nestjs-rxjs-lock/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.79.0](https://github.com/rnw-community/rnw-community/compare/v0.78.1...v0.79.0) (2024-11-18)
+
+**Note:** Version bump only for package @rnw-community/nestjs-rxjs-lock
+
 # [0.78.0](https://github.com/rnw-community/rnw-community/compare/v0.77.0...v0.78.0) (2024-11-13)
 
 **Note:** Version bump only for package @rnw-community/nestjs-rxjs-lock

--- a/packages/nestjs-rxjs-lock/package.json
+++ b/packages/nestjs-rxjs-lock/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnw-community/nestjs-rxjs-lock",
-    "version": "0.78.0",
+    "version": "0.79.0",
     "description": "NestJS RxJS lock",
     "keywords": [
         "nestjs",

--- a/packages/nestjs-rxjs-logger/CHANGELOG.md
+++ b/packages/nestjs-rxjs-logger/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.79.0](https://github.com/rnw-community/rnw-community/compare/v0.78.1...v0.79.0) (2024-11-18)
+
+**Note:** Version bump only for package @rnw-community/nestjs-rxjs-logger
+
 # [0.78.0](https://github.com/rnw-community/rnw-community/compare/v0.77.0...v0.78.0) (2024-11-13)
 
 **Note:** Version bump only for package @rnw-community/nestjs-rxjs-logger

--- a/packages/nestjs-rxjs-logger/package.json
+++ b/packages/nestjs-rxjs-logger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnw-community/nestjs-rxjs-logger",
-    "version": "0.78.0",
+    "version": "0.79.0",
     "description": "NestJS RxJS logger",
     "keywords": [
         "nestjs",

--- a/packages/nestjs-rxjs-metrics/CHANGELOG.md
+++ b/packages/nestjs-rxjs-metrics/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.79.0](https://github.com/rnw-community/rnw-community/compare/v0.78.1...v0.79.0) (2024-11-18)
+
+**Note:** Version bump only for package @rnw-community/nestjs-rxjs-metrics
+
 # [0.78.0](https://github.com/rnw-community/rnw-community/compare/v0.77.0...v0.78.0) (2024-11-13)
 
 **Note:** Version bump only for package @rnw-community/nestjs-rxjs-metrics

--- a/packages/nestjs-rxjs-metrics/package.json
+++ b/packages/nestjs-rxjs-metrics/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnw-community/nestjs-rxjs-metrics",
-    "version": "0.78.0",
+    "version": "0.79.0",
     "description": "NestJS RxJS logger",
     "keywords": [
         "nestjs",

--- a/packages/nestjs-rxjs-redis/CHANGELOG.md
+++ b/packages/nestjs-rxjs-redis/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.79.0](https://github.com/rnw-community/rnw-community/compare/v0.78.1...v0.79.0) (2024-11-18)
+
+**Note:** Version bump only for package @rnw-community/nestjs-rxjs-redis
+
 # [0.78.0](https://github.com/rnw-community/rnw-community/compare/v0.77.0...v0.78.0) (2024-11-13)
 
 **Note:** Version bump only for package @rnw-community/nestjs-rxjs-redis

--- a/packages/nestjs-rxjs-redis/package.json
+++ b/packages/nestjs-rxjs-redis/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnw-community/nestjs-rxjs-redis",
-    "version": "0.78.0",
+    "version": "0.79.0",
     "description": "NestJS RxJS redis",
     "keywords": [
         "nestjs",

--- a/packages/nestjs-typed-config/CHANGELOG.md
+++ b/packages/nestjs-typed-config/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.79.0](https://github.com/rnw-community/rnw-community/compare/v0.78.1...v0.79.0) (2024-11-18)
+
+**Note:** Version bump only for package @rnw-community/nestjs-typed-config
+
 # [0.78.0](https://github.com/rnw-community/rnw-community/compare/v0.77.0...v0.78.0) (2024-11-13)
 
 **Note:** Version bump only for package @rnw-community/nestjs-typed-config

--- a/packages/nestjs-typed-config/package.json
+++ b/packages/nestjs-typed-config/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnw-community/nestjs-typed-config",
-    "version": "0.78.0",
+    "version": "0.79.0",
     "description": "NestJS typed config",
     "keywords": [
         "nestjs",

--- a/packages/nestjs-webpack-swc/CHANGELOG.md
+++ b/packages/nestjs-webpack-swc/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.79.0](https://github.com/rnw-community/rnw-community/compare/v0.78.1...v0.79.0) (2024-11-18)
+
+**Note:** Version bump only for package @rnw-community/nestjs-webpack-swc
+
 # [0.78.0](https://github.com/rnw-community/rnw-community/compare/v0.77.0...v0.78.0) (2024-11-13)
 
 **Note:** Version bump only for package @rnw-community/nestjs-webpack-swc

--- a/packages/nestjs-webpack-swc/package.json
+++ b/packages/nestjs-webpack-swc/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnw-community/nestjs-webpack-swc",
-    "version": "0.78.0",
+    "version": "0.79.0",
     "description": "NestJS typed config",
     "keywords": [
         "nestjs",

--- a/packages/object-field-tree/CHANGELOG.md
+++ b/packages/object-field-tree/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.79.0](https://github.com/rnw-community/rnw-community/compare/v0.78.1...v0.79.0) (2024-11-18)
+
+**Note:** Version bump only for package @rnw-community/object-field-tree
+
 # [0.78.0](https://github.com/rnw-community/rnw-community/compare/v0.77.0...v0.78.0) (2024-11-13)
 
 **Note:** Version bump only for package @rnw-community/object-field-tree

--- a/packages/object-field-tree/package.json
+++ b/packages/object-field-tree/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnw-community/object-field-tree",
-    "version": "0.78.0",
+    "version": "0.79.0",
     "description": "Create a object fields combinations tree with data generator function",
     "keywords": [
         "object field tree",

--- a/packages/platform/CHANGELOG.md
+++ b/packages/platform/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.79.0](https://github.com/rnw-community/rnw-community/compare/v0.78.1...v0.79.0) (2024-11-18)
+
+**Note:** Version bump only for package @rnw-community/platform
+
 # [0.78.0](https://github.com/rnw-community/rnw-community/compare/v0.77.0...v0.78.0) (2024-11-13)
 
 **Note:** Version bump only for package @rnw-community/platform

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnw-community/platform",
-    "version": "0.78.0",
+    "version": "0.79.0",
     "description": "React native web platform utils and helpers",
     "keywords": [
         "platform utils",

--- a/packages/react-native-payments-example/CHANGELOG.md
+++ b/packages/react-native-payments-example/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.79.0](https://github.com/rnw-community/rnw-community/compare/v0.78.1...v0.79.0) (2024-11-18)
+
+### Features
+
+-   **react-native-payments:** request only contact fields asked for by the user ([#231](https://github.com/rnw-community/rnw-community/issues/231)) ([67021f7](https://github.com/rnw-community/rnw-community/commit/67021f759b5a3ef863967fad43aa28d6f9e2a20b))
+
 ## [0.78.1](https://github.com/rnw-community/rnw-community/compare/v0.78.0...v0.78.1) (2024-11-18)
 
 **Note:** Version bump only for package @rnw-community/react-native-payments-example

--- a/packages/react-native-payments-example/CHANGELOG.md
+++ b/packages/react-native-payments-example/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.78.1](https://github.com/rnw-community/rnw-community/compare/v0.78.0...v0.78.1) (2024-11-18)
+
+**Note:** Version bump only for package @rnw-community/react-native-payments-example
+
 # [0.78.0](https://github.com/rnw-community/rnw-community/compare/v0.77.0...v0.78.0) (2024-11-13)
 
 **Note:** Version bump only for package @rnw-community/react-native-payments-example

--- a/packages/react-native-payments-example/ios/Podfile.lock
+++ b/packages/react-native-payments-example/ios/Podfile.lock
@@ -1242,7 +1242,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-payments (0.76.0):
+  - react-native-payments (0.77.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1738,12 +1738,12 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 1dca942403ed9342f98334bf4c3621f011aa7946
-  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
+  DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
   FBLazyVector: 7075bb12898bc3998fd60f4b7ca422496cc2cdf7
-  fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be
-  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
+  fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
+  glog: fdfdfe5479092de0c4bdbebedd9056951f092c4f
   hermes-engine: 46f1ffbf0297f4298862068dd4c274d4ac17a1fd
-  RCT-Folly: bf5c0376ffe4dd2cf438dcf86db385df9fdce648
+  RCT-Folly: 02617c592a293bd6d418e0a88ff4ee1f88329b47
   RCTDeprecation: fde92935b3caa6cb65cbff9fbb7d3a9867ffb259
   RCTRequired: 75c6cee42d21c1530a6f204ba32ff57335d19007
   RCTTypeSafety: 7e6fe47bfb693c50d4669db1a480ca5331795f5b
@@ -1772,7 +1772,7 @@ SPEC CHECKSUMS:
   React-logger: 97c9dafae1f1a638001a9d1d0e93d431f2f9cb7b
   React-Mapbuffer: 3146a13424f9fec2ea1f1462d49d566e4d69b732
   React-microtasksnativemodule: 02d218c79c72d373a92a8552183f4ead0d1c6e05
-  react-native-payments: e6a9c6785c0203408e046780a704d3e781d2679c
+  react-native-payments: 5b58a62c9c1e821c00e9ebfce562fd243f4f71e2
   React-nativeconfig: 93fe8c85a8c40820c57814e30f3e44b94c995a7b
   React-NativeModulesApple: b3e076fd0d7b73417fe1e8c8b26e3c57ae9b74aa
   React-perflogger: 1c55bcd3c392137cbaf0d21d8bb87ce9a0cebb15

--- a/packages/react-native-payments-example/package.json
+++ b/packages/react-native-payments-example/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnw-community/react-native-payments-example",
-    "version": "0.78.0",
+    "version": "0.78.1",
     "private": true,
     "scripts": {
         "android": "react-native run-android",

--- a/packages/react-native-payments-example/package.json
+++ b/packages/react-native-payments-example/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnw-community/react-native-payments-example",
-    "version": "0.78.1",
+    "version": "0.79.0",
     "private": true,
     "scripts": {
         "android": "react-native run-android",

--- a/packages/react-native-payments-example/src/create-payment-request.ts
+++ b/packages/react-native-payments-example/src/create-payment-request.ts
@@ -1,0 +1,23 @@
+import {
+    type AndroidPaymentMethodDataInterface,
+    type IosPaymentMethodDataInterface,
+    type PaymentDetailsInit,
+    PaymentRequest,
+} from '@rnw-community/react-native-payments';
+
+import { getAndroidPaymentMethodData } from './method-data/android-payment-method-data';
+import { getIosPaymentMethodData } from './method-data/ios-payment-method-data';
+import { paymentDetails as defaultPaymentDetails } from './payment-details';
+
+interface CreatePaymentRequestProps {
+    androidPaymentMethodData?: AndroidPaymentMethodDataInterface;
+    iosPaymentMethodData?: IosPaymentMethodDataInterface;
+    paymentDetails?: PaymentDetailsInit;
+}
+
+export const createPaymentRequest = ({
+    androidPaymentMethodData = getAndroidPaymentMethodData(),
+    iosPaymentMethodData = getIosPaymentMethodData(),
+    paymentDetails = defaultPaymentDetails,
+}: CreatePaymentRequestProps = {}): PaymentRequest =>
+    new PaymentRequest([iosPaymentMethodData, androidPaymentMethodData], paymentDetails);

--- a/packages/react-native-payments-example/src/method-data/android-payment-method-data.ts
+++ b/packages/react-native-payments-example/src/method-data/android-payment-method-data.ts
@@ -1,5 +1,4 @@
 import { EnvironmentEnum } from '@rnw-community/react-native-payments';
-
 import {
     AndroidAllowedAuthMethodsEnum,
     type AndroidPaymentMethodDataInterface,
@@ -7,11 +6,27 @@ import {
     SupportedNetworkEnum,
 } from '@rnw-community/react-native-payments';
 
-export const androidPaymentMethodData: AndroidPaymentMethodDataInterface = {
+interface GetAndroidPaymentMethodDataProps {
+    requestBillingAddress?: boolean;
+    requestPayerEmail?: boolean;
+    requestPayerName?: boolean;
+    requestPayerPhone?: boolean;
+    requestShipping?: boolean;
+}
+
+export const getAndroidPaymentMethodData = ({
+    requestBillingAddress = false,
+    requestPayerEmail = false,
+    requestPayerPhone = false,
+    requestPayerName = false,
+    requestShipping = false,
+}: GetAndroidPaymentMethodDataProps = {}): AndroidPaymentMethodDataInterface => ({
     data: {
-        requestBilling: true,
-        requestShipping: true,
-        requestEmail: true,
+        requestBillingAddress,
+        requestPayerEmail,
+        requestPayerPhone,
+        requestPayerName,
+        requestShipping,
         environment: __DEV__ ? EnvironmentEnum.TEST : EnvironmentEnum.PRODUCTION,
         // USD: will not show total and merchantInfo
         currencyCode: 'EUR',
@@ -28,4 +43,4 @@ export const androidPaymentMethodData: AndroidPaymentMethodDataInterface = {
         },
     },
     supportedMethods: PaymentMethodNameEnum.AndroidPay,
-};
+});

--- a/packages/react-native-payments-example/src/method-data/ios-payment-method-data.ts
+++ b/packages/react-native-payments-example/src/method-data/ios-payment-method-data.ts
@@ -4,11 +4,27 @@ import {
     SupportedNetworkEnum,
 } from '@rnw-community/react-native-payments';
 
-export const iosPaymentMethodData: IosPaymentMethodDataInterface = {
+interface GetIOSPaymentMethodDataProps {
+    requestBillingAddress?: boolean;
+    requestPayerEmail?: boolean;
+    requestPayerName?: boolean;
+    requestPayerPhone?: boolean;
+    requestShipping?: boolean;
+}
+
+export const getIosPaymentMethodData = ({
+    requestBillingAddress = false,
+    requestPayerEmail = false,
+    requestPayerName = false,
+    requestPayerPhone = false,
+    requestShipping = false,
+}: GetIOSPaymentMethodDataProps = {}): IosPaymentMethodDataInterface => ({
     data: {
-        requestBilling: true,
-        requestShipping: true,
-        requestEmail: true,
+        requestBillingAddress,
+        requestPayerName,
+        requestPayerEmail,
+        requestPayerPhone,
+        requestShipping,
         countryCode: 'US',
         currencyCode: 'USD',
         supportedNetworks: [SupportedNetworkEnum.Visa, SupportedNetworkEnum.Mastercard],
@@ -16,4 +32,4 @@ export const iosPaymentMethodData: IosPaymentMethodDataInterface = {
         merchantIdentifier: 'merchant.react-native-payments',
     },
     supportedMethods: PaymentMethodNameEnum.ApplePay,
-};
+});

--- a/packages/react-native-payments-example/src/request-options-form.tsx
+++ b/packages/react-native-payments-example/src/request-options-form.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { Button } from 'react-native';
+
+import { PaymentComplete, type PaymentResponse } from '@rnw-community/react-native-payments';
+import { getErrorMessage } from '@rnw-community/shared';
+
+import { createPaymentRequest } from './create-payment-request';
+import { getAndroidPaymentMethodData } from './method-data/android-payment-method-data';
+import { getIosPaymentMethodData } from './method-data/ios-payment-method-data';
+import { paymentDetails as defaultPaymentDetails, paymentDetailsWithoutDisplayItems } from './payment-details';
+import { SwitchRow } from './switch-row';
+
+interface RequestOptionsFormProps {
+    readonly setError: (error: string) => void;
+    readonly setResponse: (response: PaymentResponse['details'] | undefined) => void;
+}
+
+export const RequestOptionsForm = ({ setResponse, setError }: RequestOptionsFormProps): React.ReactNode => {
+    const [requestBillingAddress, setRequestBillingAddress] = useState(false);
+    const [requestPayerEmail, setRequestPayerEmail] = useState(false);
+    const [requestPayerName, setRequestPayerName] = useState(false);
+    const [requestPayerPhone, setRequestPayerPhone] = useState(false);
+    const [requestShipping, setRequestShipping] = useState(false);
+    const [showDisplayItems, setShowDisplayItems] = useState(false);
+
+    const clearErrorAndResponse = (): void => {
+        setError('');
+        setResponse(undefined);
+    };
+
+    const handleSubmit = (): void => {
+        clearErrorAndResponse();
+        createPaymentRequest({
+            iosPaymentMethodData: getIosPaymentMethodData({
+                requestBillingAddress,
+                requestPayerEmail,
+                requestPayerName,
+                requestPayerPhone,
+                requestShipping,
+            }),
+            androidPaymentMethodData: getAndroidPaymentMethodData({
+                requestBillingAddress,
+                requestPayerEmail,
+                requestPayerName,
+                requestPayerPhone,
+                requestShipping,
+            }),
+            paymentDetails: showDisplayItems ? defaultPaymentDetails : paymentDetailsWithoutDisplayItems,
+        })
+            .show()
+            .then(paymentResponse => {
+                setResponse(paymentResponse.details);
+
+                return paymentResponse.complete(PaymentComplete.SUCCESS);
+            })
+            .catch((err: unknown) => void setError(getErrorMessage(err)));
+    };
+
+    return (
+        <>
+            <Button onPress={handleSubmit} title="ApplePay/GooglePay with following options:" />
+            <SwitchRow setValue={setRequestBillingAddress} text="requestBillingAddress" value={requestBillingAddress} />
+            <SwitchRow setValue={setRequestPayerEmail} text="requestPayerEmail" value={requestPayerEmail} />
+            <SwitchRow setValue={setRequestPayerName} text="requestPayerName" value={requestPayerName} />
+            <SwitchRow setValue={setRequestPayerPhone} text="requestPayerPhone" value={requestPayerPhone} />
+            <SwitchRow setValue={setRequestShipping} text="requestShipping" value={requestShipping} />
+            <SwitchRow setValue={setShowDisplayItems} text="showDisplayItems" value={showDisplayItems} />
+        </>
+    );
+};

--- a/packages/react-native-payments-example/src/switch-row.tsx
+++ b/packages/react-native-payments-example/src/switch-row.tsx
@@ -1,0 +1,24 @@
+import { Switch, Text, View, type ViewStyle } from 'react-native';
+
+interface SwitchRowProps {
+    readonly setValue: (val: boolean) => void;
+    readonly text: string;
+    readonly value: boolean;
+}
+
+export const SwitchRow = ({ text, value, setValue }: SwitchRowProps): React.ReactNode => (
+    <View style={viewStyle}>
+        <Text>{text}</Text>
+        <Switch
+            ios_backgroundColor="#3e3e3e"
+            onValueChange={setValue}
+            trackColor={{ false: '#767577', true: '#5BC236' }}
+            value={value}
+        />
+    </View>
+);
+
+const viewStyle: ViewStyle = {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+};

--- a/packages/react-native-payments/CHANGELOG.md
+++ b/packages/react-native-payments/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.78.1](https://github.com/rnw-community/rnw-community/compare/v0.78.0...v0.78.1) (2024-11-18)
+
+### Bug Fixes
+
+-   Corrected a typo in the supportedNetworks example code (MasterCard -> Mastercard) ([#248](https://github.com/rnw-community/rnw-community/issues/248)) ([7dd19d3](https://github.com/rnw-community/rnw-community/commit/7dd19d37b7a4b219299b73215260882dfe4ab610))
+
 # [0.78.0](https://github.com/rnw-community/rnw-community/compare/v0.77.0...v0.78.0) (2024-11-13)
 
 **Note:** Version bump only for package @rnw-community/react-native-payments

--- a/packages/react-native-payments/CHANGELOG.md
+++ b/packages/react-native-payments/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.79.0](https://github.com/rnw-community/rnw-community/compare/v0.78.1...v0.79.0) (2024-11-18)
+
+### Features
+
+-   **react-native-payments:** request only contact fields asked for by the user ([#231](https://github.com/rnw-community/rnw-community/issues/231)) ([67021f7](https://github.com/rnw-community/rnw-community/commit/67021f759b5a3ef863967fad43aa28d6f9e2a20b))
+
 ## [0.78.1](https://github.com/rnw-community/rnw-community/compare/v0.78.0...v0.78.1) (2024-11-18)
 
 ### Bug Fixes

--- a/packages/react-native-payments/app.plugin.js
+++ b/packages/react-native-payments/app.plugin.js
@@ -1,1 +1,1 @@
-module.exports = require('./plugins/withPayments');
+module.exports = require('./plugins/with-payments');

--- a/packages/react-native-payments/app.plugin.js
+++ b/packages/react-native-payments/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./plugins/withPayments');

--- a/packages/react-native-payments/package.json
+++ b/packages/react-native-payments/package.json
@@ -76,7 +76,10 @@
     },
     "gitHead": "b5608910319390f9773a9d42c3cc828e8e8a1d95",
     "dependencies": {
+        "@expo/config-plugins": "8.0.10",
         "@rnw-community/shared": "workspace:*",
+        "fs": "0.0.1-security",
+        "path": "^0.12.7",
         "react-native-uuid": "^2.0.1",
         "validator": "^13.9.0"
     },

--- a/packages/react-native-payments/package.json
+++ b/packages/react-native-payments/package.json
@@ -15,7 +15,9 @@
         "apple pay",
         "payment intents",
         "cross platform",
-        "react native payments"
+        "react native payments",
+        "expo",
+        "expo-plugin"
     ],
     "author": "Vitalii Yehorov <vitalyiegorov@gmail.com> (https://github.com/rnw-community/rnw-community/packages/react-native-payments)",
     "homepage": "https://github.com/rnw-community/rnw-community/tree/master/packages/react-native-payments",
@@ -29,6 +31,7 @@
             "import": "./dist/esm/index.js",
             "require": "./dist/cjs/index.js"
         },
+        "./app.plugin": "./app.plugin.js",
         "./package.json": "./package.json"
     },
     "react-native": "src/index.ts",
@@ -42,6 +45,8 @@
         "ios",
         "cpp",
         "*.podspec",
+        "plugins",
+        "app.plugin.js",
         "!ios/build",
         "!android/build",
         "!android/gradle",
@@ -90,7 +95,8 @@
     },
     "peerDependencies": {
         "react": ">=17",
-        "react-native": ">=0.64"
+        "react-native": ">=0.64",
+        "expo": ">=48.0.0"
     },
     "codegenConfig": {
         "name": "RNPaymentsSpec",

--- a/packages/react-native-payments/package.json
+++ b/packages/react-native-payments/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnw-community/react-native-payments",
-    "version": "0.78.0",
+    "version": "0.78.1",
     "description": "React Native Payments",
     "keywords": [
         "react",

--- a/packages/react-native-payments/package.json
+++ b/packages/react-native-payments/package.json
@@ -83,8 +83,6 @@
     "dependencies": {
         "@expo/config-plugins": "8.0.10",
         "@rnw-community/shared": "workspace:*",
-        "fs": "0.0.1-security",
-        "path": "^0.12.7",
         "react-native-uuid": "^2.0.1",
         "validator": "^13.9.0"
     },

--- a/packages/react-native-payments/package.json
+++ b/packages/react-native-payments/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnw-community/react-native-payments",
-    "version": "0.78.1",
+    "version": "0.79.0",
     "description": "React Native Payments",
     "keywords": [
         "react",

--- a/packages/react-native-payments/plugins/with-apple-pay.js
+++ b/packages/react-native-payments/plugins/with-apple-pay.js
@@ -2,14 +2,14 @@ const { withDangerousMod } = require("@expo/config-plugins");
 const fs = require("fs");
 const path = require("path");
 
-export const withApplePay = (config) =>
+const withApplePay = (config) =>
   withDangerousMod(config, [
     "ios",
     async (config) => {
       const filePath = path.join(
         config.modRequest.platformProjectRoot,
         config.modRequest.projectName,
-        "AppDelegate.h",
+        "AppDelegate.h"
       );
 
       const content = fs.readFileSync(filePath, "utf-8");
@@ -21,3 +21,4 @@ export const withApplePay = (config) =>
     },
   ]);
 
+module.exports = { withApplePay };

--- a/packages/react-native-payments/plugins/with-google-pay.js
+++ b/packages/react-native-payments/plugins/with-google-pay.js
@@ -1,6 +1,6 @@
 const { withAppBuildGradle, withAndroidManifest } = require("@expo/config-plugins");
 
-export const withGooglePay = (config) => {
+const withGooglePay = (config) => {
   // Add Google Pay dependency to app/build.gradle
   config = withAppBuildGradle(config, (config) => {
     if (config.modResults.language === "groovy") {
@@ -11,7 +11,7 @@ export const withGooglePay = (config) => {
       );
     } else {
       throw new Error(
-        "Unable to add Google Pay dependency to build.gradle: Kotlin build files are not supported.",
+        "Unable to add Google Pay dependency to build.gradle: Kotlin build files are not supported."
       );
     }
     return config;
@@ -24,7 +24,7 @@ export const withGooglePay = (config) => {
 
     // Check if the meta-data already exists
     const existingMetaData = mainApplication["meta-data"]?.find(
-      (metadata) => metadata.$["android:name"] === "com.google.android.gms.wallet.api.enabled",
+      (metadata) => metadata.$["android:name"] === "com.google.android.gms.wallet.api.enabled"
     );
 
     if (!existingMetaData) {
@@ -46,3 +46,4 @@ export const withGooglePay = (config) => {
   return config;
 };
 
+module.exports = { withGooglePay };

--- a/packages/react-native-payments/plugins/with-payments.js
+++ b/packages/react-native-payments/plugins/with-payments.js
@@ -1,6 +1,6 @@
 const { withPlugins } = require('@expo/config-plugins');
-const { withApplePay } = require('./withApplePay');
-const { withGooglePay } = require('./withGooglePay');
+const { withApplePay } = require('./with-apple-pay');
+const { withGooglePay } = require('./with-google-pay');
 
 const withPayments = (config) => {
   return withPlugins(config, [

--- a/packages/react-native-payments/plugins/with-payments.js
+++ b/packages/react-native-payments/plugins/with-payments.js
@@ -1,0 +1,12 @@
+const { withPlugins } = require('@expo/config-plugins');
+const { withApplePay } = require('./withApplePay');
+const { withGooglePay } = require('./withGooglePay');
+
+const withPayments = (config) => {
+  return withPlugins(config, [
+    withApplePay,
+    withGooglePay
+  ]);
+};
+
+module.exports = withPayments;

--- a/packages/react-native-payments/readme.md
+++ b/packages/react-native-payments/readme.md
@@ -111,8 +111,8 @@ const methodData = [
             supportedNetworks: [SupportedNetworkEnum.Visa, SupportedNetworkEnum.Mastercard],
             countryCode: 'US',
             currencyCode: 'USD',
-            requestBilling: true,
-            requestEmail: true,
+            requestBillingAddress: true,
+            requestPayerEmail: true,
             requestShipping: true
         }
     },
@@ -124,8 +124,8 @@ const methodData = [
             environment: EnvironmentEnum.Test,
             countryCode: 'DE',
             currencyCode: 'EUR',
-            requestBilling: true,
-            requestEmail: true,
+            requestBillingAddress: true,
+            requestPayerEmail: true,
             requestShipping: true,
             gatewayConfig: {
                 gateway: 'example',
@@ -153,9 +153,11 @@ const paymentRequest = new PaymentRequest(methodData, paymentDetails);
 Depending on the platform and payment method, you can provide additional data to the `methodData.data` property:
 
 - `environment`: This property represents the Android environment for the payment.
-- `requestBilling`: An optional boolean field that, when present and set to true, indicates that the `PaymentResponse` will
+- `requestPayerName`: "An optional boolean field that, when present and set to true, indicates that the `PaymentResponse` will include the name of the payer.
+- `requestPayerPhone`: "An optional boolean field that, when present and set to true, indicates that the `PaymentResponse` will include the phone of the payer. 
+- `requestBillingAddress`: An optional boolean field that, when present and set to true, indicates that the `PaymentResponse` will
   include the billing address of the payer.
-- `requestEmail`: An optional boolean field that, when present and set to true, indicates that the `PaymentResponse` will
+- `requestPayerEmail`: An optional boolean field that, when present and set to true, indicates that the `PaymentResponse` will
   include the email address of the payer.
 - `requestShipping`: An optional boolean field that, when present and set to true, indicates that the `PaymentResponse` will
   include the shipping address of the payer.

--- a/packages/react-native-payments/readme.md
+++ b/packages/react-native-payments/readme.md
@@ -81,6 +81,33 @@ dependencies {
 
 - Your google account that are you using for testing should be added to [Google Pay API Test Cards Allowlist](https://groups.google.com/g/googlepay-test-mode-stub-data?pli=1)
 
+### Expo setup
+
+To integrate with Expo custom builds, you need to add the payment plugin from the package into your `app.config.js`:
+
+1. Update your `app.config.js` configuration:
+```js
+export default {
+  expo: {
+    ...
+    ios: {
+      ...
+      infoPlist: {
+        merchant_id: [your_merchant_id],
+      },
+      entitlements: {
+        "com.apple.developer.in-app-payments": [your_merchant_id],
+      },
+      ...
+    },
+    plugins: [
+      ...
+      "@rnw-community/react-native-payments",
+    ],
+  },
+};
+```
+
 ## Usage
 
 Detailed guide should be found at:

--- a/packages/react-native-payments/readme.md
+++ b/packages/react-native-payments/readme.md
@@ -108,7 +108,7 @@ const methodData = [
         supportedMethods: PaymentMethodNameEnum.ApplePay,
         data: {
             merchantIdentifier: 'merchant.com.your-app.namespace',
-            supportedNetworks: [SupportedNetworkEnum.Visa, SupportedNetworkEnum.MasterCard],
+            supportedNetworks: [SupportedNetworkEnum.Visa, SupportedNetworkEnum.Mastercard],
             countryCode: 'US',
             currencyCode: 'USD',
             requestBilling: true,
@@ -120,7 +120,7 @@ const methodData = [
     {
         supportedMethods: PaymentMethodNameEnum.AndroidPay,
         data: {
-            supportedNetworks: [SupportedNetworkEnum.Visa, SupportedNetworkEnum.MasterCard],
+            supportedNetworks: [SupportedNetworkEnum.Visa, SupportedNetworkEnum.Mastercard],
             environment: EnvironmentEnum.Test,
             countryCode: 'DE',
             currencyCode: 'EUR',

--- a/packages/react-native-payments/src/@standard/ios/enum/ios-pk-contact-field.enum.ts
+++ b/packages/react-native-payments/src/@standard/ios/enum/ios-pk-contact-field.enum.ts
@@ -1,0 +1,7 @@
+// https://developer.apple.com/documentation/passkit_apple_pay_and_wallet/pkcontactfield?language=objc
+export enum IOSPKContactField {
+    PKContactFieldEmailAddress = 'PKContactFieldEmailAddress',
+    PKContactFieldName = 'PKContactFieldName',
+    PKContactFieldPhoneNumber = 'PKContactFieldPhoneNumber',
+    PKContactFieldPostalAddress = 'PKContactFieldPostalAddress',
+}

--- a/packages/react-native-payments/src/@standard/ios/request/ios-payment-data-request.ts
+++ b/packages/react-native-payments/src/@standard/ios/request/ios-payment-data-request.ts
@@ -1,3 +1,4 @@
+import type { IOSPKContactField } from '../enum/ios-pk-contact-field.enum';
 import type { IosPKMerchantCapability } from '../enum/ios-pk-merchant-capability.enum';
 import type { IosPKPaymentNetworksEnum } from '../enum/ios-pk-payment-networks.enum';
 
@@ -12,9 +13,9 @@ export interface IosPaymentDataRequest {
     // https://developer.apple.com/documentation/passkit/pkpaymentrequest/1619305-merchantidentifier?language=objc
     merchantIdentifier: string;
     // https://developer.apple.com/documentation/passkit/pkpaymentrequest/2865928-requiredbillingcontactfields?language=objc
-    requiredBillingContactFields?: boolean;
+    requiredBillingContactFields?: IOSPKContactField[];
     // https://developer.apple.com/documentation/passkit/pkpaymentrequest/2865927-requiredshippingcontactfields?language=objc
-    requiredShippingContactFields?: boolean;
+    requiredShippingContactFields?: IOSPKContactField[];
     // https://developer.apple.com/documentation/passkit/pkpaymentrequest/1619329-supportednetworks?language=objc
     supportedNetworks: IosPKPaymentNetworksEnum[];
 }

--- a/packages/react-native-payments/src/index.ts
+++ b/packages/react-native-payments/src/index.ts
@@ -23,3 +23,6 @@ export { IosPaymentResponse } from './class/payment-response/ios-payment-respons
 
 export { PaymentRequest } from './class/payment-request/payment-request';
 export { PaymentResponse } from './class/payment-response/payment-response';
+
+export {withApplePay} from './plugins/with-apple-pay';
+export {withGooglePay} from './plugins/with-google-pay';

--- a/packages/react-native-payments/src/index.ts
+++ b/packages/react-native-payments/src/index.ts
@@ -24,5 +24,3 @@ export { IosPaymentResponse } from './class/payment-response/ios-payment-respons
 export { PaymentRequest } from './class/payment-request/payment-request';
 export { PaymentResponse } from './class/payment-response/payment-response';
 
-export {withApplePay} from './plugins/with-apple-pay';
-export {withGooglePay} from './plugins/with-google-pay';

--- a/packages/react-native-payments/src/interface/generic-payment-method-data-data.interface.ts
+++ b/packages/react-native-payments/src/interface/generic-payment-method-data-data.interface.ts
@@ -7,9 +7,13 @@ export interface GenericPaymentMethodDataDataInterface {
     countryCode?: string;
     currencyCode: string;
     // If present PaymentResponse will have billingAddress
-    requestBilling?: boolean;
+    requestBillingAddress?: boolean;
     // If present PaymentResponse will have email
-    requestEmail?: boolean;
+    requestPayerEmail?: boolean;
+    // If present PaymentResponse will have name
+    requestPayerName?: boolean;
+    // If present PaymentResponse will have phone
+    requestPayerPhone?: boolean;
     // If present PaymentResponse will have shippingAddress
     requestShipping?: boolean;
     supportedNetworks: SupportedNetworkEnum[];

--- a/packages/react-native-payments/src/plugins/with-apple-pay.ts
+++ b/packages/react-native-payments/src/plugins/with-apple-pay.ts
@@ -1,0 +1,23 @@
+const { withDangerousMod } = require("@expo/config-plugins");
+const fs = require("fs");
+const path = require("path");
+
+export const withApplePay = (config) =>
+  withDangerousMod(config, [
+    "ios",
+    async (config) => {
+      const filePath = path.join(
+        config.modRequest.platformProjectRoot,
+        config.modRequest.projectName,
+        "AppDelegate.h",
+      );
+
+      const content = fs.readFileSync(filePath, "utf-8");
+      if (!content.includes("#import <PassKit/PassKit.h>")) {
+        fs.writeFileSync(filePath, `#import <PassKit/PassKit.h>\n${content}`);
+      }
+
+      return config;
+    },
+  ]);
+

--- a/packages/react-native-payments/src/plugins/with-google-pay.ts
+++ b/packages/react-native-payments/src/plugins/with-google-pay.ts
@@ -1,0 +1,48 @@
+const { withAppBuildGradle, withAndroidManifest } = require("@expo/config-plugins");
+
+export const withGooglePay = (config) => {
+  // Add Google Pay dependency to app/build.gradle
+  config = withAppBuildGradle(config, (config) => {
+    if (config.modResults.language === "groovy") {
+      config.modResults.contents = config.modResults.contents.replace(
+        /dependencies\s?{/,
+        `dependencies {
+    implementation 'com.google.android.gms:play-services-wallet:19.2.0'`,
+      );
+    } else {
+      throw new Error(
+        "Unable to add Google Pay dependency to build.gradle: Kotlin build files are not supported.",
+      );
+    }
+    return config;
+  });
+
+  // Add meta-data to AndroidManifest.xml
+  config = withAndroidManifest(config, async (config) => {
+    const androidManifest = config.modResults;
+    const mainApplication = androidManifest.manifest.application[0];
+
+    // Check if the meta-data already exists
+    const existingMetaData = mainApplication["meta-data"]?.find(
+      (metadata) => metadata.$["android:name"] === "com.google.android.gms.wallet.api.enabled",
+    );
+
+    if (!existingMetaData) {
+      // Add the new meta-data
+      if (!mainApplication["meta-data"]) {
+        mainApplication["meta-data"] = [];
+      }
+      mainApplication["meta-data"].push({
+        $: {
+          "android:name": "com.google.android.gms.wallet.api.enabled",
+          "android:value": "true",
+        },
+      });
+    }
+
+    return config;
+  });
+
+  return config;
+};
+

--- a/packages/redux-loadable/CHANGELOG.md
+++ b/packages/redux-loadable/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.79.0](https://github.com/rnw-community/rnw-community/compare/v0.78.1...v0.79.0) (2024-11-18)
+
+**Note:** Version bump only for package @rnw-community/redux-loadable
+
 # [0.78.0](https://github.com/rnw-community/rnw-community/compare/v0.77.0...v0.78.0) (2024-11-13)
 
 **Note:** Version bump only for package @rnw-community/redux-loadable

--- a/packages/redux-loadable/package.json
+++ b/packages/redux-loadable/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnw-community/redux-loadable",
-    "version": "0.78.0",
+    "version": "0.79.0",
     "description": "Redux loading state slice",
     "keywords": [
         "redux loading",

--- a/packages/rxjs-errors/CHANGELOG.md
+++ b/packages/rxjs-errors/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.79.0](https://github.com/rnw-community/rnw-community/compare/v0.78.1...v0.79.0) (2024-11-18)
+
+**Note:** Version bump only for package @rnw-community/rxjs-errors
+
 # [0.78.0](https://github.com/rnw-community/rnw-community/compare/v0.77.0...v0.78.0) (2024-11-13)
 
 **Note:** Version bump only for package @rnw-community/rxjs-errors

--- a/packages/rxjs-errors/package.json
+++ b/packages/rxjs-errors/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnw-community/rxjs-errors",
-    "version": "0.78.0",
+    "version": "0.79.0",
     "description": "RxJS errors utils",
     "keywords": [
         "rxjs error operator",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.79.0](https://github.com/rnw-community/rnw-community/compare/v0.78.1...v0.79.0) (2024-11-18)
+
+**Note:** Version bump only for package @rnw-community/shared
+
 # [0.78.0](https://github.com/rnw-community/rnw-community/compare/v0.77.0...v0.78.0) (2024-11-13)
 
 **Note:** Version bump only for package @rnw-community/shared

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnw-community/shared",
-    "version": "0.78.0",
+    "version": "0.79.0",
     "description": "Shared useful utils and types",
     "keywords": [
         "generic utils",

--- a/packages/wdio/CHANGELOG.md
+++ b/packages/wdio/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.79.0](https://github.com/rnw-community/rnw-community/compare/v0.78.1...v0.79.0) (2024-11-18)
+
+**Note:** Version bump only for package @rnw-community/wdio
+
 # [0.78.0](https://github.com/rnw-community/rnw-community/compare/v0.77.0...v0.78.0) (2024-11-13)
 
 **Note:** Version bump only for package @rnw-community/wdio

--- a/packages/wdio/package.json
+++ b/packages/wdio/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnw-community/wdio",
-    "version": "0.78.0",
+    "version": "0.79.0",
     "description": "WDIO commands, page objects and utils",
     "keywords": [
         "wdio",


### PR DESCRIPTION
This pull request includes several updates to the `react-native-payments` package, focusing on integrating support for Expo and adding new payment plugins for Apple Pay and Google Pay. The most important changes are listed below.

### Integration with Expo:

* Added `expo`, `expo-plugin`, and `@expo/config-plugins` as dependencies in `package.json` to support Expo integration. [[1]](diffhunk://#diff-9140d7c61cb23d744d243d1c4539521304e96a0bbd871e0045e20b82ea8d3813R84-R87) [[2]](diffhunk://#diff-9140d7c61cb23d744d243d1c4539521304e96a0bbd871e0045e20b82ea8d3813L90-R99)

### New Payment Plugins:

* Created a new plugin `withApplePay` to add necessary configurations for Apple Pay in the iOS project.
* Created a new plugin `withGooglePay` to add necessary configurations for Google Pay in the Android project.
* Combined the Apple Pay and Google Pay plugins into a single `withPayments` plugin to streamline the integration process.

### Configuration Updates:

* Updated `package.json` to include new paths and files related to the plugins. [[1]](diffhunk://#diff-9140d7c61cb23d744d243d1c4539521304e96a0bbd871e0045e20b82ea8d3813R34) [[2]](diffhunk://#diff-9140d7c61cb23d744d243d1c4539521304e96a0bbd871e0045e20b82ea8d3813R48-R49)
* Added a new module export in `app.plugin.js` to use the `withPayments` plugin.

### Documentation:

* Updated the `readme.md` to include instructions for integrating the payment plugin with Expo custom builds.